### PR TITLE
Preload metadata repos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
   repository_dispatch:
     types:
       - deploy
+  schedule:
+    - cron: '53 23 * * *'
 
 jobs:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,14 @@ RUN apt-get update \
 RUN apt-get clean \
     && rm -r /var/lib/apt/lists /var/log/dpkg.log /var/log/apt
 
+# Get game versions so we can pick a default
 RUN curl -sf -o ksp-builds.json https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/builds.json
 RUN curl -sf -o ksp2-builds.json https://raw.githubusercontent.com/KSP-CKAN/KSP2-CKAN-meta/main/builds.json
+
+# Preload metadata repos outside home dir
+RUN ckan update --asroot -g KSP
+RUN ckan update --asroot -g KSP2
+RUN mv ~/.local/share/CKAN /usr/local/share
 
 ADD mod-installer.sh /usr/local/bin/.
 

--- a/mod-installer.sh
+++ b/mod-installer.sh
@@ -12,6 +12,13 @@ then
     exit 2
 fi
 
+# Set up preloaded repo metadata
+if [[ -d /usr/local/share/CKAN -a ! -d ~/.local/share/CKAN ]]
+then
+    mkdir -p ~/.local/share
+    cp -a /usr/local/share/CKAN ~/.local/share
+fi
+
 GAME=${INPUT_GAME:-KSP}
 MAIN_GAME_VERSION=${INPUT_GAME_VERSIONS%% *}
 OTHER_GAME_VERSIONS=${INPUT_GAME_VERSIONS#* }
@@ -54,6 +61,5 @@ ckan instance fake fake_inst "$INPUT_OUTPUT_PATH" $MAIN_GAME_VERSION --game $GAM
 ckan prompt --headless <<EOF
 $COMPAT_COMMAND
 $FILTER_COMMAND
-update
 install --no-recommends $INPUT_MODS
 EOF


### PR DESCRIPTION
## Motivation

Currently the driver script runs `ckan update` at startup to get the mod metadata from the default repository of the relevant game. This takes a bit of network and time, so it would be nice to have that info already present.

## Changes

- Now during the Docker image build, we use the new update flags from KSP-CKAN/CKAN#4161 to save the metadata for KSP1 and KSP2 in `/usr/local/share/CKAN`
- Now the driver script restores that folder to `~/.local/share/CKAN` at startup to make the downloaded metadata available to CKAN
  (This is necessary because GitHub mounts its own home directory for containers in workflows, so the folder that CKAN uses for this can't be set up entirely in the Dockerfile.)
- Now the driver script no longer runs `ckan update` because it will already have the repo metadata
- Now to ensure the preloaded metadata doesn't get too stale, the deploy workflow rebuilds the Docker image every day seven minutes before midnight UTC (because [the documentation says "The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs. High load times include the start of every hour."](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule))
